### PR TITLE
Add `EqualsWithNaN` to testutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![core module docs](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/efficientgo/core)
 
-Go module with set of core packages **every** Go project needs. Minimal API, battle-tested, strictly versioned and with only one transient dependency--[davecgh/go-spew](https://github.com/davecgh/go-spew).
+Go module with set of core packages **every** Go project needs. Minimal API, battle-tested, strictly versioned and with only two transient dependencies-- [davecgh/go-spew](https://github.com/davecgh/go-spew) and [google/go-cmp](https://github.com/google/go-cmp).
 
 Maintained by experienced Go developers, including author of the [Efficient Go book](https://www.oreilly.com/library/view/efficient-go/9781098105709/).
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/efficientgo/core
 
 go 1.17
 
-require github.com/davecgh/go-spew v1.1.1
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.5.9
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -81,6 +81,9 @@ type goCmp struct {
 	opts cmp.Options
 }
 
+// WithGoCmp allows specifying options and using https://github.com/google/go-cmp
+// for equality comparisons. The compatibility guarantee of this function's arguments
+// are the same as go-cmp i.e none due to v0.x.
 func WithGoCmp(opts ...cmp.Option) goCmp {
 	return goCmp{opts: opts}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -81,7 +81,7 @@ type goCmp struct {
 	opts cmp.Options
 }
 
-func WithCmpOpts(opts ...cmp.Option) goCmp {
+func WithGoCmp(opts ...cmp.Option) goCmp {
 	return goCmp{opts: opts}
 }
 

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestContains(t *testing.T) {
@@ -97,26 +98,29 @@ func TestEqualsWithNaN(t *testing.T) {
 			a:    math.NaN(),
 			b:    math.NaN(),
 			name: "Simple NaN value comparison",
+			opts: cmp.Options{cmpopts.EquateNaNs()},
 		},
 		{
 			a:    child{Val: math.NaN()},
 			b:    child{Val: math.NaN()},
 			name: "NaN value as struct member comparison",
+			opts: cmp.Options{cmpopts.EquateNaNs()},
 		},
 		{
 			a:    parent{C: child{Val: math.NaN()}},
 			b:    parent{C: child{Val: math.NaN()}},
 			name: "NaN value in nested struct comparison",
+			opts: cmp.Options{cmpopts.EquateNaNs()},
 		},
 		{
 			a:    unexp{val: math.NaN()},
 			b:    unexp{val: math.NaN()},
 			name: "NaN value as unexported struct member comparison",
-			opts: cmp.Options{cmp.AllowUnexported(unexp{})},
+			opts: cmp.Options{cmp.AllowUnexported(unexp{}), cmpopts.EquateNaNs()},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			EqualsWithNaN(t, tc.a, tc.b, tc.opts)
+			WithCmpOpts(tc.opts).Equals(t, tc.a, tc.b)
 		})
 	}
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -3,7 +3,12 @@
 
 package testutil
 
-import "testing"
+import (
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestContains(t *testing.T) {
 	tests := map[string]struct {
@@ -65,6 +70,53 @@ func TestContains(t *testing.T) {
 			if testData.shouldMatch != contains(testData.haystack, testData.needle) {
 				t.Fatalf("unexpected result testing contains() with %#v", testData)
 			}
+		})
+	}
+}
+
+type child struct {
+	Val float64
+}
+
+type parent struct {
+	C child
+}
+
+type unexp struct {
+	val float64
+}
+
+func TestEqualsWithNaN(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    interface{}
+		b    interface{}
+		opts cmp.Options
+	}{
+		{
+			a:    math.NaN(),
+			b:    math.NaN(),
+			name: "Simple NaN value comparison",
+		},
+		{
+			a:    child{Val: math.NaN()},
+			b:    child{Val: math.NaN()},
+			name: "NaN value as struct member comparison",
+		},
+		{
+			a:    parent{C: child{Val: math.NaN()}},
+			b:    parent{C: child{Val: math.NaN()}},
+			name: "NaN value in nested struct comparison",
+		},
+		{
+			a:    unexp{val: math.NaN()},
+			b:    unexp{val: math.NaN()},
+			name: "NaN value as unexported struct member comparison",
+			opts: cmp.Options{cmp.AllowUnexported(unexp{})},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			EqualsWithNaN(t, tc.a, tc.b, tc.opts)
 		})
 	}
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -120,7 +120,7 @@ func TestEqualsWithNaN(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			WithCmpOpts(tc.opts).Equals(t, tc.a, tc.b)
+			WithGoCmp(tc.opts).Equals(t, tc.a, tc.b)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds an `EqualsWithNaN` function to `testutil` which allows comparing interfaces with `NaN` values (nested or otherwise) by considering NaN == NaN. This is useful for comparing values containing NaN in tests like `promql.Result`. 
It uses [`go-cmp`](https://pkg.go.dev/github.com/google/go-cmp) to achieve this.

`reflect.DeepEqual` considers NaN == NaN for some very specific cases which aren't easy to navigate, so an alternative implementation is necessary here. 🙂 

The limitation of `EqualsWithNaN` is that one would need to pass in special options for unexported struct fields.